### PR TITLE
Fixes switching names of biological processes

### DIFF
--- a/R/FEA.R
+++ b/R/FEA.R
@@ -120,7 +120,7 @@ FEA <- function (BPname = NULL, DEGsmatrix){
                                  "FunctionNg",
                                  "Molecules"))
 
-    TableDiseasesNew <- TableDiseasesNew[order(abs(TableDiseasesNew$Moonlight.Z.score),decreasing = TRUE),]
+    #TableDiseasesNew <- TableDiseasesNew[order(abs(TableDiseasesNew$Moonlight.Z.score),decreasing = TRUE),]
 
     return(TableDiseasesNew)
 }


### PR DESCRIPTION
Fixes #6 
Comments line in FEA function that sorts FEA output by decreasing Moonlight Z scores so assignment of biological process names are not switched 